### PR TITLE
Make nav sticky

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -6,3 +6,10 @@
 .sidebar-nav li.active > ul.children {
   display: block;
 }
+
+/* Make the top navigation sticky */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- keep sidebar nav children collapsed unless active
- make the main site header sticky so navigation stays at the top

## Testing
- `bundle exec jekyll build` *(fails: No route to host)*