### PR TITLE
Expand Article 1 menu on homepage

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<script src="{{ '/assets/js/navigation.js' | relative_url }}"></script>

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,0 +1,17 @@
+// Navigation menu behavior
+(function() {
+  function isArticlePage(path) {
+    return /\/article-\d+\//.test(path);
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var path = window.location.pathname;
+    if (!isArticlePage(path)) {
+      // assume home page -> expand article 1
+      var a1 = document.querySelector('.sidebar-nav a[href*="/article-1/"]');
+      if (a1 && a1.parentElement) {
+        a1.parentElement.classList.add('active');
+      }
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add a custom head include to load a small navigation helper
- expand the Article 1 menu items on the homepage

## Testing
- `bundle exec jekyll build` *(fails: no network access)*