### PR TITLE
Enable TOCs on article pages

### DIFF
--- a/_pages/article-1.md
+++ b/_pages/article-1.md
@@ -2,6 +2,7 @@
 title: "Article I – Introduction"
 permalink: /article-1/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-10.md
+++ b/_pages/article-10.md
@@ -2,6 +2,7 @@
 title: "Article 10 – Placeholder"
 permalink: /article-10/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-2.md
+++ b/_pages/article-2.md
@@ -2,6 +2,7 @@
 title: "Article II – General Provisions"
 permalink: /article-2/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-3.md
+++ b/_pages/article-3.md
@@ -2,6 +2,7 @@
 title: "Article 3 – Placeholder"
 permalink: /article-3/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-4.md
+++ b/_pages/article-4.md
@@ -2,6 +2,7 @@
 title: "Article 4 – Placeholder"
 permalink: /article-4/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-5.md
+++ b/_pages/article-5.md
@@ -2,6 +2,7 @@
 title: "Article 5 – Placeholder"
 permalink: /article-5/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-6.md
+++ b/_pages/article-6.md
@@ -2,6 +2,7 @@
 title: "Article 6 – Placeholder"
 permalink: /article-6/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-7.md
+++ b/_pages/article-7.md
@@ -2,6 +2,7 @@
 title: "Article 7 – Placeholder"
 permalink: /article-7/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-8.md
+++ b/_pages/article-8.md
@@ -2,6 +2,7 @@
 title: "Article 8 – Placeholder"
 permalink: /article-8/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---

--- a/_pages/article-9.md
+++ b/_pages/article-9.md
@@ -2,6 +2,7 @@
 title: "Article 9 – Placeholder"
 permalink: /article-9/
 layout: single
+toc: true
 sidebar:
   nav: "main"
 ---


### PR DESCRIPTION
## Summary
- enable Minimal Mistakes built-in Table of Contents on all article pages

## Testing
- `bundle exec jekyll build` *(fails: No route to host)*